### PR TITLE
feat(web): implement graph visualization for fragment relationships

### DIFF
--- a/api/provo/api/main.py
+++ b/api/provo/api/main.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from provo.api.routes import assumptions, decisions, fragments, search
+from provo.api.routes import assumptions, decisions, fragments, graph, search
 from provo.storage import init_database
 
 
@@ -53,3 +53,4 @@ app.include_router(fragments.router, prefix="/api/fragments", tags=["fragments"]
 app.include_router(search.router, prefix="/api/search", tags=["search"])
 app.include_router(assumptions.router, prefix="/api/assumptions", tags=["assumptions"])
 app.include_router(decisions.router, prefix="/api/decisions", tags=["decisions"])
+app.include_router(graph.router, prefix="/api/graph", tags=["graph"])

--- a/api/provo/api/routes/graph.py
+++ b/api/provo/api/routes/graph.py
@@ -1,0 +1,110 @@
+"""Graph visualization API endpoints."""
+
+from collections import Counter
+from datetime import datetime
+
+from fastapi import APIRouter
+
+from provo.api.schemas import GraphDataResponse, GraphEdge, GraphNode
+from provo.storage import SourceType, get_database
+
+router = APIRouter()
+
+
+def truncate_text(text: str, max_length: int = 60) -> str:
+    """Truncate text to max length with ellipsis."""
+    text = text.replace("\n", " ").strip()
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
+
+
+@router.get(
+    "",
+    response_model=GraphDataResponse,
+    responses={
+        200: {"description": "Graph data retrieved successfully"},
+    },
+)
+async def get_graph_data(
+    project: str | None = None,
+    source_type: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = 500,
+) -> GraphDataResponse:
+    """Get graph data for visualization.
+
+    Returns nodes (fragments) and edges (links) in a format suitable
+    for graph visualization libraries.
+
+    Args:
+        project: Filter by project name.
+        source_type: Filter by source type (quick_capture, zoom, teams, notes).
+        since: Only include fragments captured after this time.
+        until: Only include fragments captured before this time.
+        limit: Maximum number of fragments to include.
+    """
+    db = get_database()
+
+    # Parse source_type if provided
+    source_type_enum = None
+    if source_type:
+        try:
+            source_type_enum = SourceType(source_type.lower())
+        except ValueError:
+            pass  # Ignore invalid source type
+
+    # Get fragments
+    fragments = await db.list_fragments(
+        project=project,
+        source_type=source_type_enum,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+
+    # Get all links
+    links = await db.list_links(limit=5000)
+
+    # Build set of fragment IDs for quick lookup
+    fragment_ids = {str(f.id) for f in fragments}
+
+    # Count connections per fragment
+    connection_counts: Counter[str] = Counter()
+    for link in links:
+        source_id = str(link.source_id)
+        target_id = str(link.target_id)
+        if source_id in fragment_ids:
+            connection_counts[source_id] += 1
+        if target_id in fragment_ids:
+            connection_counts[target_id] += 1
+
+    # Build nodes
+    nodes = [
+        GraphNode(
+            id=str(f.id),
+            label=truncate_text(f.raw_content),
+            source_type=f.source_type,
+            project=f.project,
+            captured_at=f.captured_at,
+            topics=f.topics,
+            connections=connection_counts[str(f.id)],
+        )
+        for f in fragments
+    ]
+
+    # Build edges (only include edges where both nodes are in our set)
+    edges = [
+        GraphEdge(
+            id=str(link.id),
+            source=str(link.source_id),
+            target=str(link.target_id),
+            link_type=link.link_type.value,
+            strength=link.strength,
+        )
+        for link in links
+        if str(link.source_id) in fragment_ids and str(link.target_id) in fragment_ids
+    ]
+
+    return GraphDataResponse(nodes=nodes, edges=edges)

--- a/api/provo/api/schemas.py
+++ b/api/provo/api/schemas.py
@@ -156,3 +156,35 @@ class AssumptionUpdateRequest(BaseModel):
         None,
         description="ID of the fragment that invalidates this assumption",
     )
+
+
+# Graph visualization schemas
+
+
+class GraphNode(BaseModel):
+    """A node in the fragment relationship graph."""
+
+    id: str = Field(..., description="Fragment ID")
+    label: str = Field(..., description="Display label (truncated content)")
+    source_type: SourceType = Field(..., description="Type of fragment source")
+    project: str | None = Field(None, description="Project name")
+    captured_at: datetime = Field(..., description="When the fragment was captured")
+    topics: list[str] = Field(default_factory=list, description="Fragment topics")
+    connections: int = Field(0, description="Number of connections (for sizing)")
+
+
+class GraphEdge(BaseModel):
+    """An edge in the fragment relationship graph."""
+
+    id: str = Field(..., description="Link ID")
+    source: str = Field(..., description="Source fragment ID")
+    target: str = Field(..., description="Target fragment ID")
+    link_type: str = Field(..., description="Type of relationship")
+    strength: float = Field(..., description="Link strength (0-1)")
+
+
+class GraphDataResponse(BaseModel):
+    """Response schema for graph visualization data."""
+
+    nodes: list[GraphNode] = Field(default_factory=list, description="Graph nodes")
+    edges: list[GraphEdge] = Field(default_factory=list, description="Graph edges")

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.17.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-force-graph-2d": "^1.29.0",
         "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
@@ -1095,6 +1096,12 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1197,6 +1204,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -1205,6 +1221,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
       }
     },
     "node_modules/browserslist": {
@@ -1263,6 +1289,18 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1276,6 +1314,223 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1351,6 +1606,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.0.tgz",
+      "integrity": "sha512-aTnihCmiMA0ItLJLCbrQYS9mzriopW24goFPgUnKAAmAlPogTSmFWqoBPMXzIfPb7bs04Hur5zEI4WYgLW3Sig==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1374,6 +1669,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1407,6 +1729,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1463,6 +1803,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1499,6 +1848,27 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.28.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.1.tgz",
+      "integrity": "sha512-u1/ixq/lVQI0CakKNvLDEcW5zfCjUQfZdK9qqWuIJtsezuyG6pk9TWj75GMuI/EzRSZB/VAE43sNWWZfiy8psw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1524,6 +1894,44 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.0.tgz",
+      "integrity": "sha512-Xv5IIk+hsZmB3F2ibja/t6j/b0/1T9dtFOQacTUoLpgzRHrO6wPu1GtQ2LfRqI/imgtaapnXUgQaE8g8enPo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-refresh": {
@@ -1638,6 +2046,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/web/package.json
+++ b/web/package.json
@@ -11,10 +11,11 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.17.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0",
-    "@tanstack/react-query": "^5.17.0"
+    "react-force-graph-2d": "^1.29.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -20,6 +20,9 @@ export default function Layout() {
           <NavLink to="/timeline" className={({ isActive }) => isActive ? 'active' : ''}>
             Timeline
           </NavLink>
+          <NavLink to="/graph" className={({ isActive }) => isActive ? 'active' : ''}>
+            Graph
+          </NavLink>
         </div>
       </nav>
       <main className="main-content">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,30 @@ export interface AssumptionUpdateData {
   invalidated_by?: string;
 }
 
+// Graph visualization types
+export interface GraphNode {
+  id: string;
+  label: string;
+  source_type: 'quick_capture' | 'zoom' | 'teams' | 'notes';
+  project: string | null;
+  captured_at: string;
+  topics: string[];
+  connections: number;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  link_type: string;
+  strength: number;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
 // API base URL - uses proxy in development
 const API_BASE = '/api';
 
@@ -182,6 +206,25 @@ export const api = {
         method: 'PATCH',
         body: JSON.stringify(data),
       });
+    },
+  },
+
+  graph: {
+    getData: (params?: {
+      project?: string;
+      source_type?: string;
+      since?: string;
+      until?: string;
+      limit?: number;
+    }) => {
+      const searchParams = new URLSearchParams();
+      if (params?.project) searchParams.set('project', params.project);
+      if (params?.source_type) searchParams.set('source_type', params.source_type);
+      if (params?.since) searchParams.set('since', params.since);
+      if (params?.until) searchParams.set('until', params.until);
+      if (params?.limit) searchParams.set('limit', String(params.limit));
+      const query = searchParams.toString();
+      return fetchApi<GraphData>(`/graph${query ? `?${query}` : ''}`);
     },
   },
 };

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1,0 +1,406 @@
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
+import { api, type GraphNode } from '../lib/api';
+
+// Color mapping for source types
+const SOURCE_COLORS: Record<string, string> = {
+  quick_capture: '#1F4E8C', // Primary blue
+  zoom: '#28A745', // Green
+  teams: '#6F42C1', // Purple
+  notes: '#FFC107', // Yellow
+};
+
+// Color mapping for link types
+const LINK_COLORS: Record<string, string> = {
+  relates_to: '#666666', // Gray
+  references: '#1F4E8C', // Blue
+  follows: '#28A745', // Green
+  contradicts: '#DC3545', // Red
+  invalidates: '#FD7E14', // Orange
+};
+
+// Format date for display
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+interface GraphFilters {
+  project: string;
+  sourceType: string;
+  since: string;
+  until: string;
+}
+
+export default function Graph() {
+  const [filters, setFilters] = useState<GraphFilters>({
+    project: '',
+    sourceType: '',
+    since: '',
+    until: '',
+  });
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const graphRef = useRef<ForceGraphMethods<any, any>>();
+
+  // Fetch graph data
+  const { data: graphData, isLoading, error } = useQuery({
+    queryKey: ['graph', filters],
+    queryFn: () =>
+      api.graph.getData({
+        project: filters.project || undefined,
+        source_type: filters.sourceType || undefined,
+        since: filters.since || undefined,
+        until: filters.until || undefined,
+        limit: 500,
+      }),
+    staleTime: 60000, // 1 minute
+  });
+
+  // Fetch list of projects for filter dropdown
+  const { data: fragments } = useQuery({
+    queryKey: ['fragments', 'all'],
+    queryFn: () => api.fragments.list({ limit: 500 }),
+    staleTime: 60000,
+  });
+
+  // Extract unique projects from fragments
+  const projects = useMemo(() => {
+    if (!fragments) return [];
+    const projectSet = new Set(fragments.map((f) => f.project).filter(Boolean) as string[]);
+    return Array.from(projectSet).sort();
+  }, [fragments]);
+
+  // Transform data for force-graph
+  const graphDataForViz = useMemo(() => {
+    if (!graphData) return { nodes: [], links: [] };
+
+    return {
+      nodes: graphData.nodes.map((node) => ({
+        ...node,
+        // Size nodes by number of connections (min 5, max 15)
+        val: Math.min(15, Math.max(5, 5 + node.connections * 2)),
+        color: SOURCE_COLORS[node.source_type] || SOURCE_COLORS.quick_capture,
+      })),
+      links: graphData.edges.map((edge) => ({
+        ...edge,
+        color: LINK_COLORS[edge.link_type] || LINK_COLORS.relates_to,
+        // Width based on strength (1-5)
+        width: 1 + edge.strength * 4,
+      })),
+    };
+  }, [graphData]);
+
+  // Handle node click
+  const handleNodeClick = useCallback((node: GraphNode) => {
+    setSelectedNode(node);
+    // Center on the clicked node
+    if (graphRef.current) {
+      graphRef.current.centerAt(
+        (node as unknown as { x: number }).x,
+        (node as unknown as { y: number }).y,
+        1000
+      );
+      graphRef.current.zoom(2, 1000);
+    }
+  }, []);
+
+  // Handle background click to deselect
+  const handleBackgroundClick = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+
+  // Handle filter changes
+  const handleFilterChange = (key: keyof GraphFilters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  // Zoom controls
+  const handleZoomIn = () => {
+    if (graphRef.current) {
+      const currentZoom = graphRef.current.zoom();
+      graphRef.current.zoom(currentZoom * 1.5, 300);
+    }
+  };
+
+  const handleZoomOut = () => {
+    if (graphRef.current) {
+      const currentZoom = graphRef.current.zoom();
+      graphRef.current.zoom(currentZoom / 1.5, 300);
+    }
+  };
+
+  const handleReset = () => {
+    if (graphRef.current) {
+      graphRef.current.zoomToFit(400, 50);
+    }
+  };
+
+  // Zoom to fit on initial load
+  useEffect(() => {
+    if (graphData && graphData.nodes.length > 0 && graphRef.current) {
+      setTimeout(() => {
+        graphRef.current?.zoomToFit(400, 50);
+      }, 500);
+    }
+  }, [graphData?.nodes.length]);
+
+  if (error) {
+    return (
+      <div className="graph-page">
+        <div className="graph-error">
+          <h2>Error Loading Graph</h2>
+          <p>Failed to load graph data. Please try again.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="graph-page">
+      {/* Filters */}
+      <div className="graph-filters">
+        <div className="filter-group">
+          <label htmlFor="project-filter">Project</label>
+          <select
+            id="project-filter"
+            value={filters.project}
+            onChange={(e) => handleFilterChange('project', e.target.value)}
+          >
+            <option value="">All Projects</option>
+            {projects.map((project) => (
+              <option key={project} value={project}>
+                {project}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="source-filter">Source Type</label>
+          <select
+            id="source-filter"
+            value={filters.sourceType}
+            onChange={(e) => handleFilterChange('sourceType', e.target.value)}
+          >
+            <option value="">All Sources</option>
+            <option value="quick_capture">Quick Capture</option>
+            <option value="zoom">Zoom</option>
+            <option value="teams">Teams</option>
+            <option value="notes">Notes</option>
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="since-filter">From</label>
+          <input
+            type="date"
+            id="since-filter"
+            value={filters.since}
+            onChange={(e) => handleFilterChange('since', e.target.value)}
+          />
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="until-filter">To</label>
+          <input
+            type="date"
+            id="until-filter"
+            value={filters.until}
+            onChange={(e) => handleFilterChange('until', e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Graph stats */}
+      <div className="graph-stats">
+        <span>
+          {graphData?.nodes.length || 0} nodes, {graphData?.edges.length || 0} edges
+        </span>
+      </div>
+
+      {/* Graph container */}
+      <div className="graph-container">
+        {isLoading ? (
+          <div className="graph-loading">
+            <div className="spinner" />
+            <p>Loading graph...</p>
+          </div>
+        ) : graphDataForViz.nodes.length === 0 ? (
+          <div className="graph-empty">
+            <h3>No fragments to display</h3>
+            <p>Capture some context to see the relationship graph.</p>
+          </div>
+        ) : (
+          <ForceGraph2D
+            ref={graphRef}
+            graphData={graphDataForViz}
+            nodeLabel="label"
+            nodeColor="color"
+            nodeVal="val"
+            linkColor="color"
+            linkWidth="width"
+            linkDirectionalParticles={2}
+            linkDirectionalParticleWidth={(link) =>
+              (link as unknown as { width: number }).width
+            }
+            onNodeClick={handleNodeClick}
+            onBackgroundClick={handleBackgroundClick}
+            backgroundColor="#121317"
+            nodeCanvasObject={(node, ctx, globalScale) => {
+              // Draw node circle
+              const size = (node as unknown as { val: number }).val || 5;
+              const color = (node as unknown as { color: string }).color || '#1F4E8C';
+              const isSelected = selectedNode?.id === node.id;
+
+              ctx.beginPath();
+              ctx.arc(
+                (node as unknown as { x: number }).x || 0,
+                (node as unknown as { y: number }).y || 0,
+                size,
+                0,
+                2 * Math.PI
+              );
+              ctx.fillStyle = color;
+              ctx.fill();
+
+              // Draw selection ring
+              if (isSelected) {
+                ctx.strokeStyle = '#E0E6F0';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+              }
+
+              // Draw label on hover or when zoomed in
+              if (globalScale > 1.5 || isSelected) {
+                const label = (node as unknown as { label: string }).label || '';
+                const truncatedLabel = label.length > 30 ? label.slice(0, 30) + '...' : label;
+                const fontSize = 10 / globalScale;
+                ctx.font = `${fontSize}px Inter, sans-serif`;
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'top';
+                ctx.fillStyle = '#E0E6F0';
+                ctx.fillText(
+                  truncatedLabel,
+                  (node as unknown as { x: number }).x || 0,
+                  ((node as unknown as { y: number }).y || 0) + size + 2
+                );
+              }
+            }}
+            cooldownTicks={100}
+            warmupTicks={50}
+          />
+        )}
+
+        {/* Zoom controls */}
+        <div className="graph-controls">
+          <button onClick={handleZoomIn} title="Zoom in">
+            +
+          </button>
+          <button onClick={handleZoomOut} title="Zoom out">
+            -
+          </button>
+          <button onClick={handleReset} title="Reset view">
+            ⟲
+          </button>
+        </div>
+
+        {/* Legend */}
+        <div className="graph-legend">
+          <h4>Source Types</h4>
+          <div className="legend-items">
+            <div className="legend-item">
+              <span className="legend-dot" style={{ backgroundColor: SOURCE_COLORS.quick_capture }} />
+              Quick Capture
+            </div>
+            <div className="legend-item">
+              <span className="legend-dot" style={{ backgroundColor: SOURCE_COLORS.zoom }} />
+              Zoom
+            </div>
+            <div className="legend-item">
+              <span className="legend-dot" style={{ backgroundColor: SOURCE_COLORS.teams }} />
+              Teams
+            </div>
+            <div className="legend-item">
+              <span className="legend-dot" style={{ backgroundColor: SOURCE_COLORS.notes }} />
+              Notes
+            </div>
+          </div>
+          <h4>Link Types</h4>
+          <div className="legend-items">
+            <div className="legend-item">
+              <span className="legend-line" style={{ backgroundColor: LINK_COLORS.relates_to }} />
+              Relates to
+            </div>
+            <div className="legend-item">
+              <span className="legend-line" style={{ backgroundColor: LINK_COLORS.references }} />
+              References
+            </div>
+            <div className="legend-item">
+              <span className="legend-line" style={{ backgroundColor: LINK_COLORS.contradicts }} />
+              Contradicts
+            </div>
+            <div className="legend-item">
+              <span className="legend-line" style={{ backgroundColor: LINK_COLORS.invalidates }} />
+              Invalidates
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Selected node details panel */}
+      {selectedNode && (
+        <div className="node-details-panel">
+          <div className="panel-header">
+            <h3>Fragment Details</h3>
+            <button className="close-btn" onClick={() => setSelectedNode(null)}>
+              ✕
+            </button>
+          </div>
+          <div className="panel-content">
+            <div className="detail-row">
+              <span className="detail-label">Source</span>
+              <span className="detail-value">
+                {selectedNode.source_type.replace('_', ' ')}
+              </span>
+            </div>
+            <div className="detail-row">
+              <span className="detail-label">Date</span>
+              <span className="detail-value">{formatDate(selectedNode.captured_at)}</span>
+            </div>
+            {selectedNode.project && (
+              <div className="detail-row">
+                <span className="detail-label">Project</span>
+                <span className="detail-value">{selectedNode.project}</span>
+              </div>
+            )}
+            {selectedNode.topics.length > 0 && (
+              <div className="detail-row">
+                <span className="detail-label">Topics</span>
+                <div className="topic-tags">
+                  {selectedNode.topics.map((topic) => (
+                    <span key={topic} className="topic-tag">
+                      {topic}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="detail-row">
+              <span className="detail-label">Connections</span>
+              <span className="detail-value">{selectedNode.connections}</span>
+            </div>
+            <div className="detail-content">
+              <span className="detail-label">Content</span>
+              <p className="content-text">{selectedNode.label}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -3,6 +3,7 @@ import Layout from './components/Layout';
 import Dashboard from './pages/Dashboard';
 import Search from './pages/Search';
 import Timeline from './pages/Timeline';
+import Graph from './pages/Graph';
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,10 @@ export const router = createBrowserRouter([
       {
         path: 'timeline',
         element: <Timeline />,
+      },
+      {
+        path: 'graph',
+        element: <Graph />,
       },
     ],
   },

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -1514,3 +1514,288 @@ code {
 .assumptions-toggleable li {
   margin-bottom: var(--space-1);
 }
+
+/* ==================== Graph Page Styles ==================== */
+
+.graph-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
+  gap: var(--space-2);
+}
+
+.graph-filters {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  flex-wrap: wrap;
+}
+
+.graph-filters .filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 150px;
+}
+
+.graph-filters label {
+  font-size: var(--font-size-small);
+  color: var(--text-secondary);
+}
+
+.graph-filters select,
+.graph-filters input {
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-body);
+}
+
+.graph-filters select:focus,
+.graph-filters input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.graph-stats {
+  font-size: var(--font-size-small);
+  color: var(--text-secondary);
+  padding: 0 var(--space-1);
+}
+
+.graph-container {
+  flex: 1;
+  position: relative;
+  background: var(--bg);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--divider);
+}
+
+.graph-loading,
+.graph-empty,
+.graph-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-secondary);
+  gap: var(--space-2);
+}
+
+.graph-loading .spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--divider);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.graph-error h2 {
+  color: var(--danger);
+}
+
+.graph-empty h3 {
+  color: var(--text-primary);
+}
+
+/* Graph controls */
+.graph-controls {
+  position: absolute;
+  bottom: var(--space-2);
+  right: var(--space-2);
+  display: flex;
+  gap: 4px;
+  z-index: 10;
+}
+
+.graph-controls button {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 18px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.graph-controls button:hover {
+  background: var(--surface-hover);
+  border-color: var(--primary);
+}
+
+/* Graph legend */
+.graph-legend {
+  position: absolute;
+  top: var(--space-2);
+  left: var(--space-2);
+  background: rgba(30, 33, 48, 0.9);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--divider);
+  z-index: 10;
+  max-width: 180px;
+}
+
+.graph-legend h4 {
+  font-size: var(--font-size-small);
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-1) 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.graph-legend h4:not(:first-child) {
+  margin-top: var(--space-2);
+}
+
+.legend-items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-small);
+  color: var(--text-primary);
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legend-line {
+  width: 20px;
+  height: 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+/* Node details panel */
+.node-details-panel {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  width: 320px;
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--divider);
+  box-shadow: var(--shadow-card);
+  z-index: 20;
+  max-height: calc(100% - var(--space-4));
+  overflow: auto;
+}
+
+.node-details-panel .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--divider);
+}
+
+.node-details-panel .panel-header h3 {
+  margin: 0;
+  font-size: var(--font-size-h3);
+  color: var(--text-primary);
+}
+
+.node-details-panel .close-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px;
+  line-height: 1;
+}
+
+.node-details-panel .close-btn:hover {
+  color: var(--text-primary);
+}
+
+.node-details-panel .panel-content {
+  padding: var(--space-2);
+}
+
+.node-details-panel .detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-1);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--divider);
+}
+
+.node-details-panel .detail-row:last-of-type {
+  border-bottom: none;
+}
+
+.node-details-panel .detail-label {
+  font-size: var(--font-size-small);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.node-details-panel .detail-value {
+  font-size: var(--font-size-body);
+  color: var(--text-primary);
+  text-align: right;
+}
+
+.node-details-panel .topic-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.node-details-panel .topic-tag {
+  font-size: var(--font-size-small);
+  background: var(--surface-hover);
+  color: var(--text-secondary);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.node-details-panel .detail-content {
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--divider);
+}
+
+.node-details-panel .detail-content .detail-label {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.node-details-panel .content-text {
+  font-size: var(--font-size-body);
+  color: var(--text-primary);
+  line-height: 1.5;
+  margin: 0;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary

- Add interactive force-directed graph visualization using react-force-graph-2d
- Create `/api/graph` endpoint with filtering support (project, source_type, date range)
- Implement node coloring by source type and edge coloring by link type
- Add node sizing based on connection count
- Include details panel, zoom controls, and legend

## Changes

### Backend
- Add `GraphNode`, `GraphEdge`, `GraphDataResponse` schemas
- Add `list_links()` method to database
- Create graph router with filtering capabilities

### Frontend
- Install react-force-graph-2d library
- Create `Graph.tsx` page with full visualization
- Add navigation link and routing
- Add comprehensive CSS styles

## Test plan

- [ ] Verify graph renders with 100+ fragments
- [ ] Test filter controls (project, source type, date range)
- [ ] Verify node click shows details panel
- [ ] Test zoom controls (+, -, reset)
- [ ] Verify legend displays correctly
- [ ] Check color coding for source types and link types

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)